### PR TITLE
feat: add linting for clang-format

### DIFF
--- a/backend/.clang-format
+++ b/backend/.clang-format
@@ -1,0 +1,13 @@
+---
+# Style based on google but with 4 space indents
+BasedOnStyle: Google
+IndentWidth: 4
+---
+Language: Cpp
+DerivePointerAlignment: False
+PointerAlignment: Left
+ColumnLimit: 115
+AllowShortFunctionsOnASingleLine: None
+IndentAccessModifiers: False
+AccessModifierOffset: -4
+---


### PR DESCRIPTION
Use clang format. Should be available on vscode [here](https://marketplace.visualstudio.com/items?itemName=xaver.clang-format)